### PR TITLE
Improving the Configuration and Networking  in the docker-compose File 

### DIFF
--- a/quickstart-docker-actus-rf20.yml
+++ b/quickstart-docker-actus-rf20.yml
@@ -1,19 +1,37 @@
+version: '3.8'
+
 services:
-  mongodb: #specify the service name as specified in application.properties of actus-service / actus-riskservice
-    image: mongodb/mongodb-community-server:6.0-ubi8 #public mongodb base image
+  mongodb:
+    image: mongodb/mongodb-community-server:6.0-ubi8
+    command: mongod --bind_ip_all
     ports:
-      - "27018:27017" # Change to the appropriate port if needed
+      - "27017:27017"  
     volumes:
       - mongo_data:/data/db
+    networks:
+      - actus-network
 
-  actus-riskserver-ce: # specify service name as specified in application.properties of actus-service
-    image: fnparr/actus-riskserver-ce:mdb27018   #currently local image (needs to be built first) will be replaced with a published imaged
+  actus-riskserver-ce:
+    image: mtoub/actus-riskserver-ce:mdb27018
     ports:
-      - "8082:8082" # Change to the appropriate port if needed
+      - "8082:8082"
+    environment:
+      - SPRING_DATA_MONGODB_URI=mongodb://mongodb:27017/actusdb
+    depends_on:
+      - mongodb
+    networks:
+      - actus-network
 
   actus-server-rf20:
-    image: fnparr/actus-server-rf20:nodb #currently local image (needs to be built first) will be replaced with a published image
+    image: mtoub/actus-server-rf20:nodb
     ports:
-      - "8083:8083"  # Change to the appropriate port if needed
+      - "8083:8083"
+    networks:
+      - actus-network
+
 volumes:
   mongo_data:
+
+networks:
+  actus-network:
+    driver: bridge


### PR DESCRIPTION
This pull request includes changes to the `quickstart-docker-actus-rf20.yml` file to improve the configuration and networking of the Docker services. The most important changes include updating the Docker Compose version, modifying service configurations, and adding a custom network.

Configuration improvements:

* Updated Docker Compose version to `3.8` for better compatibility and features.

Service modifications:

* Added `command: mongod --bind_ip_all` to the `mongodb` service to ensure it listens on all IP addresses.
* Updated image references for `actus-riskserver-ce` and `actus-server-rf20` services to use images from `mtoub` instead of `fnparr`.
* Added `environment` and `depends_on` configurations to the `actus-riskserver-ce` service to set the MongoDB URI and ensure it starts after the `mongodb` service.

Networking enhancements:

* Added a custom network `actus-network` and assigned it to all services to improve network isolation and communication.